### PR TITLE
add: 모달 컴포넌트 구현

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,10 +2,13 @@
 <html lang="kr">
   <head>
     <meta charset="utf-8" />
-    <meta name="description" content="설로인 관리자 페이지 | 상품등록 페이지 입니다." />
+    <meta
+      name="description"
+      content="설로인 관리자 페이지 | 상품등록 페이지 입니다." />
     <title>설로인 관리자 | 상품등록 페이지</title>
   </head>
   <body>
     <div id="root"></div>
+    <div id="modal"></div>
   </body>
 </html>

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+import { StyledCommonSaveBtn } from 'components/common-button/CommonBtns';
+import * as S from 'components/modal/style';
+
+function Modal({ onClose, message }) {
+  return (
+    <S.Background>
+      <S.Contents>
+        <S.Message>{message}</S.Message>
+        <S.ButtonBox>
+          <StyledCommonSaveBtn onClick={onClose}>닫기</StyledCommonSaveBtn>
+        </S.ButtonBox>
+      </S.Contents>
+    </S.Background>
+  );
+}
+
+Modal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  message: PropTypes.string.isRequired,
+};
+
+export default Modal;

--- a/src/components/modal/portal.js
+++ b/src/components/modal/portal.js
@@ -1,0 +1,8 @@
+import reactDom from 'react-dom';
+
+function Portal({ children }) {
+  const node = document.getElementById('modal');
+  return reactDom.createPortal(children, node);
+}
+
+export default Portal;

--- a/src/components/modal/style.js
+++ b/src/components/modal/style.js
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+export const Background = styled.div`
+  position: fixed;
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  align-items: start;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.25);
+`;
+
+export const Contents = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin: 5rem;
+  padding: 2rem 1.5rem;
+  width: 350px;
+  min-height: 150px;
+  border-radius: 5px;
+  background: #fff;
+`;
+
+export const Message = styled.p``;
+
+export const ButtonBox = styled.div`
+  align-self: flex-end;
+`;


### PR DESCRIPTION
## 타입

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Other

## 구현사항

1. 배경이 어두워지는 모달 컴포넌트 구현
2. 메세지와 onclose를 props로 받음

사용법

```jsx
//포탈과 모달 컴포넌트는 compoenet/modal 안에 있습니다.

function Practice() {
  const [isModalOpen, setIsModalOpen] = useState(false);

  return (
      <div>
        <button type="button" onClick={() => setIsModalOpen(true)}>
          모달 여는 버튼
        </button>
        {isModalOpen && (
          <Portal>
            <Modal message="메세지" onClose={() => setIsModalOpen(false)} />
          </Portal>
        )}
      </div>
  );
}
```

## 체크리스트

- [ ] Linked Issues에서 적절한 이슈 하나를 걸어두었습니다.
- [ ] 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [ ] 기능이 제대로 실행되는지 확인 하였습니다.
- [ ] npm start로 구현한 화면 혹은 기능을 확인할 수 있습니다.

## 특이 사항
